### PR TITLE
close #144 既存のスペックで発見できなかったバグに対応

### DIFF
--- a/spec/views/sheets/hard.html.slim_spec.rb
+++ b/spec/views/sheets/hard.html.slim_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'sheets/hard.html.slim', type: :request do
   context '楽曲更新時', js: true do
     before do
       create(:sheet, id: 1, active: true)
-      create(:score, id: 1, user_id: 1, sheet_id: 1, state: 6)
+      create(:score, id: 100, user_id: 1, sheet_id: 1, state: 6)
       login_as(user, scope: :user, run_callbacks: false)
       visit sheet_path(iidxid: user.iidxid, type: 'hard')
     end
@@ -38,14 +38,14 @@ RSpec.describe 'sheets/hard.html.slim', type: :request do
 
     it '楽曲が更新でき，ログが作られている' do
       wait_for_ajax
-      expect(Score.find_by(id: 1).state).to eq 6
+      expect(Score.find_by(id: 100).state).to eq 6
       expect(Log.exists?(user_id: 1, sheet_id: 1, pre_state: 6, new_state: 3)).to eq false
       click_on 'MyString'
       sleep(1)
       select 'CLEAR', from: 'score_state'
       click_on '更新'
       visit sheet_path(iidxid: user.iidxid, type: 'clear')
-      expect(Score.find_by(id: 1).state).to eq 3
+      expect(Score.find_by(id: 100).state).to eq 3
       expect(Log.exists?(user_id: 1, sheet_id: 1, pre_state: 6, new_state: 3)).to eq true
     end
   end


### PR DESCRIPTION
既存のスペックはsheetとscoreのidが同一だった
edit時にはsheet.idでscoreを検索し，
update時にはscore.idでscoreを検索していたため，
本番環境ではバグを発生していた．
その修正を行った．