### PR TITLE
refs #266 backupをsubmoduleの管理下から外す

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@
 
 .DS_Store
 /vendor/assets/bower_components
+.submodules/backup-abilitysheet


### PR DESCRIPTION
refs #266 
gitからは外すが，ディレクトリ構成，バックアップ体制は維持する．