### PR TITLE
close #340 csrfトークンが切れている場合はreloadさせる

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -63,4 +63,9 @@ class ApplicationController < ActionController::Base
   def miniprofiler
     Rack::MiniProfiler.authorize_request if user_signed_in? && current_user.admin?
   end
+
+  def handle_unverified_request
+    flash[:alert] = 'ページのトークンが切れています，再度お試し下さい'
+    render :reload
+  end
 end

--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -1,4 +1,4 @@
-if Rails.env.production?
+unless Rails.env.test?
   Airbrake.configure do |config|
     config.project_id  = ENV['ERRBIT_API_KEY']
     config.project_key = ENV['ERRBIT_API_KEY']


### PR DESCRIPTION
refs #340 

`render: reload` が常に効く場所であるかが心配要素．
何かしらコレでエラーが出るならsharedに定義したほうがよいかもしれない．
ただ以前render時にsharedを使おうとしたら上手く行かなかった覚えが有るので，
とりあえずこれで様子見．