### PR TITLE
close #376 user destroy logs

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -59,6 +59,20 @@ class LogsController < ApplicationController
     @color = Static::COLOR
   end
 
+  def destroy
+    if current_user.owner?
+      log = Log.find(params[:id])
+      Score.find_by(user_id: log.user_id, sheet_id: log.sheet_id, version: Abilitysheet::Application.config.iidx_version).update_column(:state, log.pre_state)
+    else
+      log = current_user.logs.find_by(id: params[:id])
+      current_user.scores.find_by(sheet_id: log.sheet_id, version: Abilitysheet::Application.config.iidx_version).update_column(:state, log.pre_state)
+    end
+    Redis.new.set(:recent200, User.recent200.to_json)
+    flash[:notice] = "#{Sheet.find(log.sheet_id).title}のログを削除し，状態を戻しました"
+    log.destroy
+    render :reload
+  end
+
   def graph
     @user = User.find_by(iidxid: params[:id])
     unless @user

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -18,8 +18,8 @@ html
 
     - tmp_recent = nil
     - if current_user && current_user.logs.exists?
-      - recent = link_to '最近の更新', log_path(current_user.iidxid, User.find_by(id: current_user.id).logs.order(:created_date).last.created_date)
-      - tmp_recent = log_path(current_user.iidxid, User.find_by(id: current_user.id).logs.order(:created_date).last.created_date)
+      - recent = link_to '最近の更新', logs_path(current_user.iidxid, User.find_by(id: current_user.id).logs.order(:created_date).last.created_date)
+      - tmp_recent = logs_path(current_user.iidxid, User.find_by(id: current_user.id).logs.order(:created_date).last.created_date)
     = react_component 'Navbar', { recent: tmp_recent }, { class: 'uk-navbar uk-navbar-attached', tag: :nav }
 
     .uk-offcanvas#navbar-offcanvas

--- a/app/views/logs/_logs.html.slim
+++ b/app/views/logs/_logs.html.slim
@@ -5,6 +5,6 @@ table.uk-table.uk-table-hover.uk-table-striped.uk-table-condensed
   tbody
     - @logs.each do |log|
       tr
-        td = link_to log.created_date, log_path(params[:id], log.created_date)
+        td = link_to log.created_date, logs_path(params[:id], log.created_date)
         td = @user.logs.select(:id).where(created_date: log.created_date).count
 = paginate @logs, remote: true, total_pages: @total_pages

--- a/app/views/logs/show.html.slim
+++ b/app/views/logs/show.html.slim
@@ -22,7 +22,7 @@ form.uk-form
       - @logs.each do |log|
         tr
           td
-            - if current_user.iidxid == params[:id] || current_user.owner?
+            - if user_signed_in? && (current_user.iidxid == params[:id] || current_user.owner?)
               = link_to log_path(log.id), method: :delete, remote: true, class: 'uk-button uk-button-mini uk-button-danger',  data: { confirm: '削除してよろしいですか？ランプは旧ランプの状態へ戻ります' }
                 = fa_icon 'trash', text: '削除'
               |&nbsp;&nbsp;

--- a/app/views/logs/show.html.slim
+++ b/app/views/logs/show.html.slim
@@ -1,12 +1,12 @@
 - @title = @logs.first.created_date
 p
   - if @prev_update
-    = link_to @prev_update, log_path(params[:id], @prev_update)
+    = link_to @prev_update, logs_path(params[:id], @prev_update)
     | &nbsp;<&nbsp;
   = @logs.first.created_date
   - if @next_update
     | &nbsp;>&nbsp;
-    = link_to @next_update, log_path(params[:id], @next_update)
+    = link_to @next_update, logs_path(params[:id], @next_update)
 form.uk-form
   table.uk-table.datatable
     thead
@@ -21,7 +21,12 @@ form.uk-form
     tbody
       - @logs.each do |log|
         tr
-          td = log.title
+          td
+            - if current_user.iidxid == params[:id] || current_user.owner?
+              = link_to log_path(log.id), method: :delete, remote: true, class: 'uk-button uk-button-mini uk-button-danger',  data: { confirm: '削除してよろしいですか？ランプは旧ランプの状態へ戻ります' }
+                = fa_icon 'trash', text: '削除'
+              |&nbsp;&nbsp;
+            = log.title
           td
             = log.new_score
             - diff = log.new_score.to_i - log.pre_score.to_i

--- a/app/views/shared/_list.html.slim
+++ b/app/views/shared/_list.html.slim
@@ -20,7 +20,7 @@ table.datatable
         td.center bgcolor=user.dan_color = user.dan
         td.center = user.belongs
         - if score
-          td.center = link_to score.updated_at, log_path(user.iidxid, score.updated_at)
+          td.center = link_to score.updated_at, logs_path(user.iidxid, score.updated_at)
           td.center = score.title
           td.center bgcolor=Static::COLOR[score.state]
         - else

--- a/app/views/users/_list.html.slim
+++ b/app/views/users/_list.html.slim
@@ -18,7 +18,7 @@ table.datatable
         td.center = iidxid
         td.center bgcolor=Static::GRADECOLOR[user[:grade].to_i] = Static::GRADE[user[:grade].to_i]
         td.center = Static::PREF[user[:pref].to_i]
-        td.center = link_to user[:updated_at], log_path(iidxid, user[:updated_at])
+        td.center = link_to user[:updated_at], logs_path(iidxid, user[:updated_at])
         td.center = user[:title]
         td.center bgcolor=Static::COLOR[user[:state].to_i]
         - if user_signed_in?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,14 +53,14 @@ Rails.application.routes.draw do
   resources :scores, only: [:edit, :update]
 
   # log
-  resources :logs, only: [] do
+  resources :logs, only: :destroy do
     get :graph, on: :member
     get :list, on: :member
     get :sheet, on: :member
     post :manager, on: :member
     post :iidxme, on: :member
   end
-  get '/logs/:id/:date' => 'logs#show', as: :log
+  get '/logs/:id/:date' => 'logs#show', as: :logs
 
   # recommends
   resources :recommends, only: [:index]

--- a/spec/features/logs/show_logs_spec.rb
+++ b/spec/features/logs/show_logs_spec.rb
@@ -1,0 +1,77 @@
+feature 'ログの詳細画面', js: true do
+  background do
+    @user = create(:user, id: 1, iidxid: '1234-5678', role: User::Role::GENERAL)
+    create(:sheet, id: 1, title: 'log spec1')
+    create(:sheet, id: 2, title: 'log spec2')
+    create(:score, sheet_id: 1, state: 6, user_id: 1)
+    create(:score, sheet_id: 2, state: 6, user_id: 1)
+    create(:log, sheet_id: 1, user_id: 1, created_date: Date.today, pre_state: 7, new_state: 6)
+    create(:log, sheet_id: 2, user_id: 1, created_date: Date.today, pre_state: 7, new_state: 6)
+    visit logs_path(@user.iidxid, Date.today.to_s)
+    wait_for_ajax
+  end
+
+  scenario 'ログが存在する' do
+    expect(page).to have_content('log spec1')
+    expect(page).to have_content('log spec2')
+  end
+
+  context 'ログイン時' do
+    background { login(@user) }
+    context '自分のログページの場合' do
+      scenario '削除ボタンが存在する' do
+        visit logs_path(@user.iidxid, Date.today.to_s)
+        wait_for_ajax
+        expect(page).to have_content('削除')
+      end
+      scenario 'ログが削除できる' do
+        expect(Log.where(user_id: @user.id).count).to eq 2
+        expect(Score.exists?(user_id: @user.id, state: 7)).to eq false
+        click_link '削除', match: :first
+        wait_for_ajax
+        expect(Log.where(user_id: @user.id).count).to eq 1
+        expect(Score.exists?(user_id: @user.id, state: 7)).to eq true
+      end
+    end
+    context '他人のログページの場合' do
+      background do
+        @user2 = create(:user, id: 2, username: 'user2', iidxid: '2234-5678', role: User::Role::GENERAL)
+        create(:score, sheet_id: 1, state: 6, user_id: 2)
+        create(:score, sheet_id: 2, state: 6, user_id: 2)
+        create(:log, sheet_id: 1, user_id: 2, created_date: Date.today, pre_state: 7, new_state: 6)
+        create(:log, sheet_id: 2, user_id: 2, created_date: Date.today, pre_state: 7, new_state: 6)
+        visit logs_path(@user2.iidxid, Date.today.to_s)
+        wait_for_ajax
+      end
+      context 'User::Role::GENERALの場合' do
+        scenario '削除ボタンが存在しない' do
+          expect(page).to have_no_content('削除')
+        end
+      end
+      context 'User::Role::OWNERの場合' do
+        background do
+          @user.update(role: User::Role::OWNER)
+          visit logs_path(@user2.iidxid, Date.today.to_s)
+          wait_for_ajax
+        end
+        scenario '削除ボタンが存在する' do
+          expect(page).to have_content('削除')
+        end
+        scenario 'ログが削除できる' do
+          expect(Log.where(user_id: @user2.id).count).to eq 2
+          expect(Score.exists?(user_id: @user2.id, state: 7)).to eq false
+          click_link '削除', match: :first
+          wait_for_ajax
+          expect(Log.where(user_id: @user2.id).count).to eq 1
+          expect(Score.exists?(user_id: @user2.id, state: 7)).to eq true
+        end
+      end
+    end
+  end
+
+  context '非ログイン時' do
+    scenario '削除ボタンが存在しない' do
+      expect(page).to have_no_content('削除')
+    end
+  end
+end


### PR DESCRIPTION
refs #376 

ユーザは自身のログ，オーナーは全てのログを削除することができる．
削除時にはログが作られる前のランプの色へと戻す処理も追加．
このとき，updated_atが更新されるとログが存在しない日付が一覧に載るため，updated_atは更新しない．
また，Redisの最新の200人は取得し直す．