### PR TITLE
close #489 不要なメソッドを削除

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,13 +16,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def scores_exists?
-    return if current_user.scores.present?
-    flash[:alert] = '処理を受け付けませんでした．'
-    flash[:notice] = 'この状態が続くようであればお問い合わせください'
-    render :reload
-  end
-
   def return_404
     render file: Rails.root.join('public', '404.html'), status: 404, layout: true, content_type: 'text/html'
   end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,5 +1,4 @@
 class LogsController < ApplicationController
-  # before_action :scores_exists?, only: %w(manager iidxme)
   before_action :special_user!, only: %w(update_official)
   before_action :load_user, only: %w(sheet list show)
 


### PR DESCRIPTION
refs #489 
現在はスコアレコードがなければ生成されるようになっているため，
この条件は不要である．

そして使われていないため，削除する．