### PR TITLE
[#786] throw out newrelic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'kaminari'
 gem 'levenshtein'
 gem 'mechanize'
 gem 'mini_magick'
-gem 'newrelic_rpm'
 gem 'nokogiri'
 # }}}
 # o,p,q,r,s,t,u {{{
@@ -30,11 +29,11 @@ gem 'peek-gc'
 gem 'peek-performance_bar'
 gem 'peek-pg'
 gem 'peek-rblineprof'
-gem 'peek-redis', '1.1.0'
+gem 'peek-redis'
 gem 'peek-sidekiq'
 gem 'pg'
 gem 'pry-rails'
-gem 'pry-byebug'
+# gem 'pry-remote'
 gem 'puma'
 gem 'rails'
 gem 'rails_admin'
@@ -64,6 +63,10 @@ group :development do
   gem 'rack-dev-mark'
   gem 'rails-erd'
   gem 'spring'
+end
+
+group :development, :test do
+  gem 'pry-byebug'
 end
 
 group :staging, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,6 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
-    newrelic_rpm (3.17.1.326)
     nio4r (1.2.1)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
@@ -276,7 +275,7 @@ GEM
     peek-rblineprof (0.1.2)
       peek
       rblineprof
-    peek-redis (1.1.0)
+    peek-redis (1.2.0)
       atomic (>= 1.0.0)
       peek
       redis
@@ -535,7 +534,6 @@ DEPENDENCIES
   mechanize
   meta_request
   mini_magick
-  newrelic_rpm
   nokogiri
   oauth2
   peek
@@ -544,7 +542,7 @@ DEPENDENCIES
   peek-performance_bar
   peek-pg
   peek-rblineprof
-  peek-redis (= 1.1.0)
+  peek-redis
   peek-sidekiq
   pg
   poltergeist


### PR DESCRIPTION
- Since problems of alias_method of newrelic and prepend of peek-redis intertwine with each other
ref: https://github.com/newrelic/rpm/blob/master/lib/new_relic/agent/instrumentation/redis.rb#L57

close #786